### PR TITLE
Fixed menu with duplicated items

### DIFF
--- a/ui-bundles/widgets/entando-widget-navigation_bar/src/main/resources/sql/bundles/entando-widget-navigation_bar/port_data_production.sql
+++ b/ui-bundles/widgets/entando-widget-navigation_bar/src/main/resources/sql/bundles/entando-widget-navigation_bar/port_data_production.sql
@@ -44,7 +44,8 @@ INSERT INTO guifragment (code, widgettypecode, plugincode, gui, defaultgui, lock
 	</#if>
 </#if>
 
-</ul>', 1);
+</ul>
+<@wp.freemarkerTemplateParameter var="previousPage" valueName="" removeOnEndTag=true />', 1);
 
 INSERT INTO guifragment (code, widgettypecode, plugincode, gui, defaultgui, locked) VALUES ('entando-widget-navigation_bar_include', NULL, NULL, NULL, '<#assign wp=JspTaglibs["/aps-core"]>
 <#assign c=JspTaglibs["http://java.sun.com/jsp/jstl/core"]>

--- a/ui-bundles/widgets/entando-widget-navigation_menu/src/main/resources/sql/bundles/entando-widget-navigation_menu/port_data_production.sql
+++ b/ui-bundles/widgets/entando-widget-navigation_menu/src/main/resources/sql/bundles/entando-widget-navigation_menu/port_data_production.sql
@@ -37,7 +37,8 @@ INSERT INTO guifragment (code, widgettypecode, plugincode, gui, defaultgui, lock
    </#if>
 </#if>
 </ul>
-</div>', 1);
+</div>
+<@wp.freemarkerTemplateParameter var="previousPage" valueName="" removeOnEndTag=true />', 1);
 
 INSERT INTO guifragment (code, widgettypecode, plugincode, gui, defaultgui, locked) VALUES ('entando-widget-navigation_menu_include', NULL, NULL, NULL, '<#assign c=JspTaglibs["http://java.sun.com/jsp/jstl/core"]>
 <#assign wp=JspTaglibs["/aps-core"]>


### PR DESCRIPTION
Fixed menu with duplicated items. This commit is related to the issue #12 
The problem is due to the use of variable previousPage not yet initialized.

If a widget, or a template in general, use a variable not yet initialized, at the second usage in the same page, you could get this anomaly..

We must ensure that this does not happen in other widgets.