### PR TITLE
Javadoc plugin configuration based on profile

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -87,6 +87,17 @@
         <module>entando-plugin-jpblog</module>
         -->
     </modules>
+    <profiles>
+    	<profile>
+            <id>java8</id>
+           	<activation>
+            	<jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+            	<javadoc.opts>-Xdoclint:none</javadoc.opts>
+        	</properties>
+    	</profile>
+    </profiles>
     <properties>
         <!--
         <test.database.driver>org.postgresql.Driver</test.database.driver>
@@ -133,8 +144,7 @@
                             <goal>jar</goal>
                         </goals>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-							<failOnError>false</failOnError>
+							<additionalparam>${javadoc.opts}</additionalparam>
 						</configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Additional param configuration for javadoc plugin managed by profile with automatic activation instead of uncomment / failOnError. The profile java8-doclint-disabled evaluate property javadoc.opts with value -Xdoclint:none required on java 8 environment 