### PR TITLE
removed duplicate mvn plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,15 +144,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<target>1.6</target>
-					<source>1.6</source>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.3.1</version>
 				<executions>


### PR DESCRIPTION
this fixes this error `'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate ` 