### PR TITLE
[4.3.4] EN-1857-434-read-and-save-metadata-on-images-in-multiple-uploader

### DIFF
--- a/plugins/entando-plugin-jpversioning/src/test/java/com/agiletec/plugins/jpversioning/aps/system/services/resource/MockResourceDataBean.java
+++ b/plugins/entando-plugin-jpversioning/src/test/java/com/agiletec/plugins/jpversioning/aps/system/services/resource/MockResourceDataBean.java
@@ -29,108 +29,121 @@ import java.util.List;
 
 import com.agiletec.aps.system.services.category.Category;
 import com.agiletec.plugins.jacms.aps.system.services.resource.model.ResourceDataBean;
+import java.util.Map;
 
 /**
  * @author E.Santoboni
  */
 public class MockResourceDataBean implements ResourceDataBean {
-	
-	@Override
-	public String getResourceId() {
-		return _resourceId;
-	}
-	public void setResourceId(String resourceId) {
-		this._resourceId = resourceId;
-	}
-	
-	/**
-	 * Restituisce il tipo di risorsa.
-	 * @return Il tipo di risorsa.
-	 */
-	public String getResourceType() {
-		return _resourceType;
-	}
-	
-	/**
-	 * Setta il tipo di risorsa.
-	 * @param type Il tipo di risorsa.
-	 */
-	public void setResourceType(String type) {
-		this._resourceType = type;
-	}
-	
-	/**
-	 * Setta la descrizione della risorsa.
-	 * @param descr La descrizione della risorsa.
-	 */
-	public void setDescr(String descr) {
-		this._descr = descr;
-	}
-	
-	/**
-	 * Restituisce la descrizione della risorsa.
-	 * @return La descrizione della risorsa.
-	 */
-	public String getDescr() {
-		return _descr;
-	}
-	
-	/**
-	 * Setta il file relativo alla risorsa.
-	 * @param file Il file relativo alla risorsa.
-	 */
-	public void setFile(File file) {
-		this._file = file;
-	}
-	
-	public String getMainGroup() {
-		return _mainGroup;
-	}
-	
-	public void setMainGroup(String mainGroup) {
-		this._mainGroup = mainGroup;
-	}
-	
-	public List<Category> getCategories() {
-		return _categories;
-	}
-	
-	public void setCategories(List<Category> categories) {
-		this._categories = categories;
-	}
-	
-	public int getFileSize() {
-		return (int) this._file.length()/1000;
-	}
-	
-	public InputStream getInputStream() throws Throwable {
-		return new FileInputStream(this._file);
-	}
-	
-	public String getFileName() {
-		String filename = _file.getName().substring(_file.getName().lastIndexOf('/')+1).trim();
-		return filename;
-	}
-	
-	public String getMimeType() {
-		return _mimeType;
-	}
-	public void setMimeType(String mimetype) {
-		this._mimeType = mimetype;
-	}
-	
-	@Override
-	public File getFile() {
-		return _file;
-	}
-	
-	private String _resourceId;
 
-	private String _resourceType;
-	private String _descr;
-	private String _mainGroup;
-	private File _file;
-	private List<Category> _categories = new ArrayList<Category>();
-	private String _mimeType;
-	
+    private String _resourceId;
+    private String _resourceType;
+    private String _descr;
+    private String _mainGroup;
+    private File _file;
+    private List<Category> _categories = new ArrayList<Category>();
+    private String _mimeType;
+    Map<String, String> metadata;
+
+    @Override
+    public String getResourceId() {
+        return _resourceId;
+    }
+
+    public void setResourceId(String resourceId) {
+        this._resourceId = resourceId;
+    }
+
+    /**
+     * Restituisce il tipo di risorsa.
+     *
+     * @return Il tipo di risorsa.
+     */
+    public String getResourceType() {
+        return _resourceType;
+    }
+
+    /**
+     * Setta il tipo di risorsa.
+     *
+     * @param type Il tipo di risorsa.
+     */
+    public void setResourceType(String type) {
+        this._resourceType = type;
+    }
+
+    /**
+     * Setta la descrizione della risorsa.
+     *
+     * @param descr La descrizione della risorsa.
+     */
+    public void setDescr(String descr) {
+        this._descr = descr;
+    }
+
+    /**
+     * Restituisce la descrizione della risorsa.
+     *
+     * @return La descrizione della risorsa.
+     */
+    public String getDescr() {
+        return _descr;
+    }
+
+    /**
+     * Setta il file relativo alla risorsa.
+     *
+     * @param file Il file relativo alla risorsa.
+     */
+    public void setFile(File file) {
+        this._file = file;
+    }
+
+    public String getMainGroup() {
+        return _mainGroup;
+    }
+
+    public void setMainGroup(String mainGroup) {
+        this._mainGroup = mainGroup;
+    }
+
+    public List<Category> getCategories() {
+        return _categories;
+    }
+
+    public void setCategories(List<Category> categories) {
+        this._categories = categories;
+    }
+
+    public int getFileSize() {
+        return (int) this._file.length() / 1000;
+    }
+
+    public InputStream getInputStream() throws Throwable {
+        return new FileInputStream(this._file);
+    }
+
+    public String getFileName() {
+        String filename = _file.getName().substring(_file.getName().lastIndexOf('/') + 1).trim();
+        return filename;
+    }
+
+    public String getMimeType() {
+        return _mimeType;
+    }
+
+    public void setMimeType(String mimetype) {
+        this._mimeType = mimetype;
+    }
+
+    @Override
+    public File getFile() {
+        return _file;
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
 }

--- a/plugins/src/test/config/conf/systemParams.properties
+++ b/plugins/src/test/config/conf/systemParams.properties
@@ -54,6 +54,7 @@ jacms.workContentSearcher.forceCaseInsensitiveLikeSearch=false
 
 jacms.imageResource.allowedExtensions=jpg,jpeg,png
 jacms.attachResource.allowedExtensions=pdf,xls,doc,ppt,txt,rtf,sxw,sxc,odt,ods,odp,tar,gz,zip,rar,flv,swf,avi,wmv,ogg,mp3,wav,ogm,mov,iso,nrg,docx,docm,xlsx,xlsm,xlsb,pptx,pptm,ppsx,ppsm,sldx,sldm
+jacms.imgMetadata.ignoreKeys=Blue TRC,Red TRC,Green TRC
 
 ##----------------------
 ## Database configuration


### PR DESCRIPTION
Hey @joewhite101 @eugeniosant ,
read and save metadata on images in multiple uploader added.

It should be merged a the same time with the entando-core PR below:
https://github.com/entando/entando-core/pull/547

Thanks!