### PR TITLE
En 2359

### DIFF
--- a/plugins/entando-plugin-jacms/src/main/resources/spring/plugins/jacms/aps/managers/cmsManagersConfig.xml
+++ b/plugins/entando-plugin-jacms/src/main/resources/spring/plugins/jacms/aps/managers/cmsManagersConfig.xml
@@ -23,7 +23,7 @@
         <property name="resourceDAO" >
             <bean class="com.agiletec.plugins.jacms.aps.system.services.resource.ResourceDAO">
                 <property name="dataSource" ref="portDataSource" />
-                <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/portDataSourceClassName" /></property>
+                <property name="dataSourceClassName"><value>${portDataSourceClassName}</value></property>
             </bean>
         </property>
         <property name="resourceTypes">
@@ -72,12 +72,12 @@
     
     <bean id="jacmsPublicContentSearcherDAO" class="com.agiletec.plugins.jacms.aps.system.services.content.PublicContentSearcherDAO">
         <property name="dataSource" ref="portDataSource" />
-        <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/portDataSourceClassName" /></property>
+        <property name="dataSourceClassName"><value>${portDataSourceClassName}</value></property>
     </bean>
     
     <bean id="jacmsWorkContentSearcherDAO"  class="com.agiletec.plugins.jacms.aps.system.services.content.WorkContentSearcherDAO">
         <property name="dataSource" ref="portDataSource" />
-        <property name="dataSourceClassName"><jee:jndi-lookup jndi-name="java:comp/env/portDataSourceClassName" /></property>
+        <property name="dataSourceClassName"><value>${portDataSourceClassName}</value></property>
     </bean>
     
     <bean id="jacmsContentAuthorizationHelper" class="com.agiletec.plugins.jacms.aps.system.services.content.helper.ContentAuthorizationHelper" >

--- a/plugins/entando-plugin-jacms/src/main/resources/spring/plugins/jacms/aps/managers/cmsManagersConfig.xml
+++ b/plugins/entando-plugin-jacms/src/main/resources/spring/plugins/jacms/aps/managers/cmsManagersConfig.xml
@@ -127,7 +127,7 @@
             <bean class="com.agiletec.plugins.jacms.aps.system.services.searchengine.SearchEngineDAOFactory" 
                               init-method="init">
                 <property name="indexDiskRootFolder">
-                    <jee:jndi-lookup jndi-name="java:comp/env/indexDiskRootFolder" />
+                    <value>${indexDiskRootFolder}</value>
                 </property>
                 <property name="configManager" ref="BaseConfigManager"/>
                 <property name="langManager" ref="LangManager" />

--- a/plugins/entando-plugin-jacms/src/main/resources/spring/plugins/jacms/aps/managers/resourceTypesDef.xml
+++ b/plugins/entando-plugin-jacms/src/main/resources/spring/plugins/jacms/aps/managers/resourceTypesDef.xml
@@ -19,7 +19,7 @@
 	<bean id="jacmsAbstractResource" abstract="true" 
 			class="com.agiletec.plugins.jacms.aps.system.services.resource.model.AbstractResource" >
 		<property name="storageManager" ref="StorageManager" />
-		<property name="protectedBaseURL" ><jee:jndi-lookup jndi-name="java:comp/env/protectedResourceRootURL" /></property>
+		<property name="protectedBaseURL" ><value>${protectedResourceRootURL}</value></property>
                 <property name="metadataIgnoreKeys"><value>${jacms.imgMetadata.ignoreKeys}</value></property>
         </bean>
 	

--- a/plugins/entando-plugin-jpehcache/src/main/resources/spring/plugins/jpehcache/aps/baseManagersConfig.xml
+++ b/plugins/entando-plugin-jpehcache/src/main/resources/spring/plugins/jpehcache/aps/baseManagersConfig.xml
@@ -13,7 +13,7 @@
 	<cache:annotation-driven cache-manager="springCacheManager" />
 	
 	<bean id="springEhCacheFactoryManager" class="org.entando.entando.plugins.jpehcache.aps.system.services.EhCacheManagerFactoryBean" p:config-location="classpath:ehcache.xml">
-		<property name="applicationBaseUrl"><jee:jndi-lookup jndi-name="java:comp/env/applicationBaseURL" /></property>
+		<property name="applicationBaseUrl"><value>${applicationBaseURL}</value></property>
 	</bean>
 	
 	<bean id="springCacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" p:cache-manager-ref="springEhCacheFactoryManager"/>

--- a/plugins/entando-plugin-jprss/src/test/resources/spring/systemConfig.xml
+++ b/plugins/entando-plugin-jprss/src/test/resources/spring/systemConfig.xml
@@ -16,11 +16,11 @@
 	<bean id="ApsSystemUtils" class="com.agiletec.aps.system.ApsSystemUtils" init-method="init" >
 		<property name="systemParams">
 		<map>
-			<entry key="logName"><jee:jndi-lookup jndi-name="java:comp/env/logName" /></entry>
-			<entry key="logFilePrefix"><jee:jndi-lookup jndi-name="java:comp/env/logFilePrefix" /></entry>
-			<entry key="logLevel"><jee:jndi-lookup jndi-name="java:comp/env/logLevel" /></entry>
-			<entry key="logFileSize"><jee:jndi-lookup jndi-name="java:comp/env/logFileSize" /></entry>
-			<entry key="logFilesCount"><jee:jndi-lookup jndi-name="java:comp/env/logFilesCount" /></entry>
+			<entry key="logName" ><value>${logName}</value></entry>
+			<entry key="logFilePrefix"><value>${logFilePrefix}</value></entry>
+			<entry key="logLevel"><value>${logLevel}</value></entry>
+			<entry key="logFileSize"><value>${logFileSize}</value></entry>
+			<entry key="logFilesCount"><value>${logFilesCount}</value></entry>
 		</map>
 		</property>
 	</bean>

--- a/plugins/entando-plugin-jpwebform/src/main/resources/spring/plugins/jpwebform/aps/managers/jpwebformManagers.xml
+++ b/plugins/entando-plugin-jpwebform/src/main/resources/spring/plugins/jpwebform/aps/managers/jpwebformManagers.xml
@@ -91,7 +91,7 @@
 	<bean id="jpwebformGuiGeneratorManager" class="org.entando.entando.plugins.jpwebform.aps.system.services.form.GuiGeneratorManager"
 			parent="abstractService" >
 		<property name="formManager" ref="jpwebformFormManager" />
-		<property name="resourceDiskRootFolder" ><jee:jndi-lookup jndi-name="java:comp/env/resourceDiskRootFolder" /></property>
+		<property name="resourceDiskRootFolder" ><value>${resourceDiskRootFolder}</value></property>
 	</bean>
 	
 	<bean id="jpwebformUserGuiGenerator" class="org.entando.entando.plugins.jpwebform.aps.system.services.form.UserGuiGenerator" >


### PR DESCRIPTION
I have modified a couple of Spring xml configs to use property placeholders, e.g. ${my.prop} instead of JNDI Environment Entry lookups. As discussed in the Spring documentation (https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html), this allows existing JNDI Environment Entries to still take precedence for legacy projects, but allows new projects to omit these entries in favour of OS environment variables. This has been extremely useful in making our images more flexible and dynamically configurable.