### PR TITLE
DE improvements, added tests

### DIFF
--- a/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/aps/system/jpa/ByteArrayStringSerializer.java
+++ b/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/aps/system/jpa/ByteArrayStringSerializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019-Present Entando Inc. (http://www.entando.com) All rights reserved.
+ * 
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+package org.entando.entando.aps.system.jpa;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Jackson serializer used to serialize a byte[] into a String (by default
+ * Jackson converts the byte array into a String encoded in Base64). This is
+ * particularly useful to serialize JPA entities having some @Lob fields (long
+ * blobs) that should always be defined using byte[] instead of String to avoid
+ * compatibility issues between different RDBMS (e.g. using Derby a String will
+ * always be converted into a varchar(255) even if it is annotated by @Lob).
+ */
+public class ByteArrayStringSerializer extends StdSerializer<byte[]> {
+
+    private static final long serialVersionUID = 1L;
+
+    public ByteArrayStringSerializer() {
+        super(byte[].class);
+    }
+
+    @Override
+    public void serialize(byte[] bytes, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        String value = bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
+        gen.writeString(value);
+    }
+}

--- a/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/aps/system/jpa/servdb/DigitalExchangeJob.java
+++ b/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/aps/system/jpa/servdb/DigitalExchangeJob.java
@@ -16,6 +16,8 @@ package org.entando.entando.aps.system.jpa.servdb;
 import com.agiletec.aps.system.SystemConstants;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.entando.entando.aps.system.jpa.ByteArrayStringSerializer;
 import org.entando.entando.aps.system.services.digitalexchange.job.JobStatus;
 import org.entando.entando.aps.system.services.digitalexchange.job.JobType;
 
@@ -97,8 +99,10 @@ public class DigitalExchangeJob implements Serializable {
     @Column(name = COL_JOB_TYPE)
     private JobType jobType;
 
+    @Lob
     @Column(name = COL_ERROR_MESSAGE)
-    private String errorMessage;
+    @JsonSerialize(using = ByteArrayStringSerializer.class)
+    private byte[] errorMessage;
 
     @PrePersist
     protected void onCreate() {
@@ -178,11 +182,11 @@ public class DigitalExchangeJob implements Serializable {
         this.status = status;
     }
 
-    public String getErrorMessage() {
+    public byte[] getErrorMessage() {
         return errorMessage;
     }
 
-    public void setErrorMessage(String errorMessage) {
+    public void setErrorMessage(byte[] errorMessage) {
         this.errorMessage = errorMessage;
     }
 

--- a/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/aps/system/services/digitalexchange/DigitalExchangesServiceImpl.java
+++ b/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/aps/system/services/digitalexchange/DigitalExchangesServiceImpl.java
@@ -152,7 +152,7 @@ public class DigitalExchangesServiceImpl implements DigitalExchangesService {
         try {
             updateWithRemotePublicKey(digitalExchange);
         } catch (Exception ex) {
-            logger.error("An error occurred while downloading public key for digital exchange " + digitalExchange.getId());
+            logger.error("An error occurred while downloading public key for digital exchange {}", digitalExchange.getId());
             digitalExchange.invalidate();
         }
     }

--- a/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/aps/system/services/digitalexchange/job/JobRunner.java
+++ b/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/aps/system/services/digitalexchange/job/JobRunner.java
@@ -40,7 +40,7 @@ public abstract class JobRunner {
             } catch (Throwable ex) {
                 logger.error("Error while executing job " + job.getId(), ex);
                 job.setStatus(JobStatus.ERROR);
-                job.setErrorMessage(ex.getMessage());
+                job.setErrorMessage(ex.getMessage().getBytes());
                 job.setEnded(new Date());
                 jobService.save(job);
             }

--- a/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/web/digitalexchange/job/DigitalExchangeJobResource.java
+++ b/plugins/entando-plugin-jpdigital-exchange/src/main/java/org/entando/entando/web/digitalexchange/job/DigitalExchangeJobResource.java
@@ -30,7 +30,7 @@ public interface DigitalExchangeJobResource {
     @ApiOperation(value = "Get a Digital Exchange job by id")
     @ApiResponses({
             @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 404, message = "Not FOund")
+            @ApiResponse(code = 404, message = "Not Found")
     })
     @RestAccessControl(permission = Permission.SUPERUSER)
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/plugins/entando-plugin-jpdigital-exchange/src/test/java/org/entando/entando/aps/system/services/digitalexchange/DigitalExchangeTestUtils.java
+++ b/plugins/entando-plugin-jpdigital-exchange/src/test/java/org/entando/entando/aps/system/services/digitalexchange/DigitalExchangeTestUtils.java
@@ -15,15 +15,9 @@ package org.entando.entando.aps.system.services.digitalexchange;
 
 import org.apache.logging.log4j.util.Strings;
 import org.entando.entando.aps.system.services.digitalexchange.model.DigitalExchange;
-import org.entando.entando.aps.system.services.digitalexchange.signature.SignatureUtil;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.KeyPair;
 
 public final class DigitalExchangeTestUtils {
 

--- a/plugins/entando-plugin-jpdigital-exchange/src/test/java/org/entando/entando/aps/system/services/digitalexchange/job/DigitalExchangeComponentJobsServiceTest.java
+++ b/plugins/entando-plugin-jpdigital-exchange/src/test/java/org/entando/entando/aps/system/services/digitalexchange/job/DigitalExchangeComponentJobsServiceTest.java
@@ -66,7 +66,7 @@ public class DigitalExchangeComponentJobsServiceTest {
         }
 
         assertThat(job.getStatus()).isEqualTo(JobStatus.ERROR);
-        assertThat(job.getErrorMessage()).isEqualTo(errorMsg);
+        assertThat(job.getErrorMessage()).isEqualTo(errorMsg.getBytes());
     }
 
     @Test(expected = ValidationConflictException.class)

--- a/plugins/entando-plugin-jpdigital-exchange/src/test/java/org/entando/entando/web/digitalexchange/job/DigitalExchangeJobResourceControllerIntegrationTest.java
+++ b/plugins/entando-plugin-jpdigital-exchange/src/test/java/org/entando/entando/web/digitalexchange/job/DigitalExchangeJobResourceControllerIntegrationTest.java
@@ -113,6 +113,8 @@ public class DigitalExchangeJobResourceControllerIntegrationTest extends Abstrac
     public void shouldReturnSingleJob() throws Exception {
 
         DigitalExchangeJob job1 = new DigitalExchangeJob();
+        String errorMsg = "error";
+        job1.setErrorMessage(errorMsg.getBytes());
         String jobId = repo.save(job1).getId();
 
         ResultActions result = createAuthRequest(get("/digitalExchange/jobs/{jobId}", jobId)).execute();
@@ -121,7 +123,8 @@ public class DigitalExchangeJobResourceControllerIntegrationTest extends Abstrac
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.errors").isEmpty())
                 .andExpect(jsonPath("$.metaData").isEmpty())
-                .andExpect(jsonPath("$.payload.id", is(jobId)));
+                .andExpect(jsonPath("$.payload.id", is(jobId)))
+                .andExpect(jsonPath("$.payload.errorMessage", is(errorMsg)));
     }
 
     @Test


### PR DESCRIPTION
The main change in this PR is modifying the definition of the `errorMessage` field in the `DigitalExchangeJob` class from String to byte[]. This is necessary because in case of fatal errors we store the exception stack trace, but if it is too long a JPA exception could happen during the save because the text exceeds the length of the column in the database.