### PR TITLE
fix query rimozione contenuto online

### DIFF
--- a/plugins/entando-plugin-jacms/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/ContentDAO.java
+++ b/plugins/entando-plugin-jacms/src/main/java/com/agiletec/plugins/jacms/aps/system/services/content/ContentDAO.java
@@ -116,7 +116,7 @@ public class ContentDAO extends AbstractEntityDAO implements IContentDAO {
 	private final String REMOVE_ONLINE_CONTENT = "UPDATE contents SET onlinexml = ? , published = ? , sync = ? , "
             + "status = ? , workxml = ? , lastmodified = ? , currentversion = ? , lasteditor = ? WHERE contentid = ? ";
 
-	private final String REMOVE_ONLINE_CONTENT_WITHOUT_DATE = "UPDATE contents SET onlinexml = ? , sync = ? , "
+	private final String REMOVE_ONLINE_CONTENT_WITHOUT_DATE = "UPDATE contents SET onlinexml = ? , published = ? , sync = ? , "
             + "status = ? , workxml = ? , currentversion = ? , lasteditor = ? WHERE contentid = ? ";
 
 	private final String UPDATE_CONTENT = "UPDATE contents SET contenttype = ? , descr = ? , status = ? , "


### PR DESCRIPTION
Correzione bug per la rimozione di un contenuto online, quando il parametro updateDate è a false. Attualmente il metodo con il parametro a false era invocato solo dal plugin contentScheduler