### PR TITLE
ENG-186: Fixes the validation for the Content Viewer widget when Config is empty

### DIFF
--- a/plugins/entando-plugin-jacms/src/main/java/org/entando/entando/plugins/jacms/aps/system/services/widgettype/validators/ContentViewerWidgetValidator.java
+++ b/plugins/entando-plugin-jacms/src/main/java/org/entando/entando/plugins/jacms/aps/system/services/widgettype/validators/ContentViewerWidgetValidator.java
@@ -63,8 +63,13 @@ public class ContentViewerWidgetValidator implements WidgetConfigurationValidato
         try {
             logger.debug("validating widget {} for page {}", widget.getCode(), page.getCode());
             String contentId = WidgetValidatorCmsHelper.extractConfigParam(widget, WIDGET_CONFIG_KEY_CONTENT_ID);
-            WidgetValidatorCmsHelper.validateSingleContentOnPage(widget.getCode(), page, contentId, this.getContentManager(), bindingResult);
-            this.validateContentModel(widget, bindingResult);
+            if (null != contentId) {
+                WidgetValidatorCmsHelper
+                        .validateSingleContentOnPage(widget.getCode(), page, contentId, this.getContentManager(),
+                                bindingResult);
+
+                this.validateContentModel(widget, bindingResult);
+            }
         } catch (ApsSystemException e) {
             logger.error("error in validate wiget {} in page {}", widget.getCode(), page.getCode());
             throw new RestServerError("error in widget config validation", e);


### PR DESCRIPTION
Hi @joewhite101 @Kerruba ,
this PR fix the 500 error when the user set the "on the fly" flag for the Content Viewer Widget (set in the main frame) in the page configuration.

Could you please have a look?
Thanks